### PR TITLE
chore: use linode-obs sloth fork for download_url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,8 +30,7 @@ install() {
   fi
 
   local download_url
-  download_url="https://github.com/slok/sloth/releases/download/v${version}/sloth-${platform}-${arch}"
-
+  download_url="https://github.com/linode-obs/sloth/releases/download/v${version}/sloth-${platform}-${arch}"
   mkdir -p "${bin_install_path}"
 
   echo "Downloading sloth from ${download_url}"


### PR DESCRIPTION
This PR updates the download_url used to point to our fork of Sloth instead of upstream so we can get the benefits of asdf while waiting for our changes to be merged upstream to Sloth